### PR TITLE
Remove clojars

### DIFF
--- a/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
+++ b/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
@@ -117,7 +117,6 @@ open class IHMCBuildExtension(val project: Project)
    fun configureDependencyResolution()
    {
       declareMavenCentral()
-      repository("https://clojars.org/repo/")
       repository("https://github.com/rosjava/rosjava_mvn_repo/raw/master")
       repository("https://raw.githubusercontent.com/ihmcrobotics/maven-artifacts-archive/main/")
       repository("https://jitpack.io")


### PR DESCRIPTION
The only thing I found which used something from the clojars repos was an unused ROS1 library for loading ROS bags.[ I've removed that dependency](https://github.com/ihmcrobotics/ihmc-open-robotics-software/commit/ed6db1d0cb3b7f32250ed23a8be67986de5c7236) from ihmc-open-robotics-software and ensured nothing else used anything from clojars.

