### PR TITLE
Add publishing support for ossrh staging portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,17 @@ So you can use the `:` character to sepcify the extra source set project and the
 
 ##### Publishing releases
 
-Set `publishUsername` and `publishPassword` in `~/.gradle/gradle.properties` to your Sonatype JIRA credentials.
+Set `publishUsername` and `publishPassword` in `~/.gradle/gradle.properties` to your Sonatype Maven Central credentials (https://central.sonatype.com/).
 
 `gradle publish -PpublishUrl=ihmcRelease`
 
-The above command publishes `your-project-0.1.0.jar` to Maven Central if the `openSource` option is set to "true" in the `ihmc` block. 
-Otherwise, it will publish to Artifactory `proprietary-releases`.
+The above command publishes `your-project-0.1.0.jar` to OSSRH Staging API (see below) if the `openSource` option is set to "true" in the `ihmc` block. 
+Otherwise, it will publish to IHMC Nexus `proprietary-releases`.
+
+###### OSSRH Staging API
+If publishing to OSSRH Staging API (the default if `openSource` is true), a GPG key is required to sign the artifacts. Install gpg on your system and create a keypair if you don't already have one.
+
+Once published, you must manually go to the Deployments page on Maven Central Repository (https://central.sonatype.com/publishing) and click Publish on the new Deployment.
 
 ##### Publishing locally
 

--- a/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
+++ b/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
@@ -17,8 +17,11 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.SigningExtension
 import java.io.File
 import java.io.FileInputStream
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.*
 
 open class IHMCBuildExtension(val project: Project)
@@ -237,7 +240,7 @@ open class IHMCBuildExtension(val project: Project)
             {
                if (openSource)
                {
-                  declareMavenCentral("releases")
+                  declareMavenCentral()
                }
                else
                {
@@ -248,7 +251,7 @@ open class IHMCBuildExtension(val project: Project)
             {
                if (openSource)
                {
-                  declareMavenCentral("releases")
+                  declareMavenCentral()
                }
                else
                {
@@ -269,6 +272,16 @@ open class IHMCBuildExtension(val project: Project)
             val java = extensions.getByType(JavaPluginExtension::class.java)
 
             declarePublication(name, java.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME))
+         }
+      }
+
+      if (openSource)
+      {
+         project.afterEvaluate {
+            val publishTask = project.tasks.findByName("publish")
+            publishTask?.doLast {
+               callOSSRHStagingPortalAPI()
+            }
          }
       }
    }
@@ -537,14 +550,16 @@ open class IHMCBuildExtension(val project: Project)
       }
    }
 
-   fun Project.declareMavenCentral(repoName: String)
+   fun Project.declareMavenCentral()
    {
       val publishing = extensions.getByType(PublishingExtension::class.java)
       publishing.repositories.maven {
-         name = "MavenCentral" + IHMCBuildTools.kebabToPascalCase(repoName)
-         url = uri("https://s01.oss.sonatype.org/content/repositories/$repoName/")
-         credentials.username = publishUsername
-         credentials.password = publishPassword
+         name = "ossrh-staging-api"
+         url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+         credentials {
+            username = publishUsername
+            password = publishPassword
+         }
       }
    }
 
@@ -590,6 +605,14 @@ open class IHMCBuildExtension(val project: Project)
          licenseNode.appendNode("name", licenseName)
          licenseNode.appendNode("url", licenseURL)
          licenseNode.appendNode("distribution", "repo")
+
+         val scmNode = asNode().appendNode("scm")
+         scmNode.appendNode("url", vcsUrl)
+
+         val developersNode = asNode().appendNode("developers")
+         val developerNode = developersNode.appendNode("developer")
+         developerNode.appendNode("name", maintainer)
+         developerNode.appendNode("organization", companyName)
       }
 
       publication.artifact(tasks.withType<Jar>().getByName("jar"))
@@ -598,6 +621,11 @@ open class IHMCBuildExtension(val project: Project)
          from(sourceSet.allJava)
          archiveClassifier.set("sources")
       })
+
+      val signing = extensions.getByType(SigningExtension::class.java)
+      signing.useGpgCmd()
+      LogTools.info("Signing publication $name")
+      signing.sign(publication)
    }
 
    private fun Project.addPOMDependenciesForConfiguration(dependenciesNode: Node,
@@ -667,6 +695,38 @@ open class IHMCBuildExtension(val project: Project)
                exclusions[key]!!.add(excludeRule)
             }
          }
+      }
+   }
+
+   private fun callOSSRHStagingPortalAPI()
+   {
+      LogTools.info("Uploading artifacts to Maven Central Publishing from OSSRH Staging Portal")
+
+      val url = URL("https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/us.ihmc")
+      val connection = url.openConnection() as HttpURLConnection
+
+      return try
+      {
+         val credentials = "$publishUsername:$publishPassword"
+         val credentialsEncoded = Base64.getEncoder().encodeToString(credentials.toByteArray())
+         connection.requestMethod = "POST"
+         connection.setRequestProperty("accept", "*/*")
+         connection.setRequestProperty(
+               "Authorization",
+               "Bearer $credentialsEncoded"
+         )
+         connection.doOutput = true
+         connection.outputStream.use { /* empty body */ }
+      }
+      catch (e: Exception)
+      {
+         e.printStackTrace()
+      }
+      finally
+      {
+         connection.disconnect()
+
+         LogTools.warn("You are not finished publishing! Please visit https://central.sonatype.com/publishing/deployments to publish the newly created deployment")
       }
    }
 }

--- a/src/main/kotlin/us/ihmc/build/IHMCBuildPlugin.kt
+++ b/src/main/kotlin/us/ihmc/build/IHMCBuildPlugin.kt
@@ -2,7 +2,8 @@ package us.ihmc.build
 
 import ca.cutterslade.gradle.analyze.AnalyzeDependenciesPlugin
 import com.dorongold.gradle.tasktree.TaskTreePlugin
-import org.gradle.api.*
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.HelpTasksPlugin
 import org.gradle.api.plugins.JavaLibraryPlugin
@@ -12,6 +13,7 @@ import org.gradle.api.tasks.Delete
 import org.gradle.kotlin.dsl.create
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.plugins.signing.SigningPlugin
 import us.ihmc.cd.AppExtension
 import us.ihmc.cd.RemoteExtension
 import us.ihmc.ci.IHMCCIPlugin
@@ -42,6 +44,7 @@ class IHMCBuildPlugin : Plugin<Project>
             pluginManager.apply(JavaLibraryPlugin::class.java)
             pluginManager.apply(IvyPublishPlugin::class.java)
             pluginManager.apply(MavenPublishPlugin::class.java)
+            pluginManager.apply(SigningPlugin::class.java)
             pluginManager.apply(AnalyzeDependenciesPlugin::class.java)
             pluginManager.apply(EclipsePlugin::class.java)
             pluginManager.apply(IdeaPlugin::class.java)


### PR DESCRIPTION
New requirements when publishing:
- gpg key (the signing plugin uses gpg executable, will use the key in the default directory)
- Visiting the deployments page and clicking publish after running the publish gradle task

![Screenshot_2025-06-18_10-58-40](https://github.com/user-attachments/assets/feb7da29-c97d-45e5-92b5-2844999499a3)
