### PR TITLE
Better message on publish

### DIFF
--- a/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
+++ b/src/main/kotlin/us/ihmc/build/IHMCBuildExtension.kt
@@ -719,6 +719,37 @@ open class IHMCBuildExtension(val project: Project)
          )
          connection.doOutput = true
          connection.outputStream.use { /* empty body */ }
+
+         if (connection.responseCode != 200)
+         {
+            val responseBody = try {
+               connection.inputStream.bufferedReader().use { it.readText() }
+            } catch (e: Exception) {
+               connection.errorStream?.bufferedReader()?.use { it.readText() } ?: ""
+            }
+
+            project.gradle.buildFinished {
+               LogTools.error("")
+               LogTools.error("")
+               LogTools.error("")
+               LogTools.error("There was an error when trying to call the OSSRH Staging Portal API. Response code: ${connection.responseCode}. Response body: $responseBody")
+               LogTools.error("")
+               LogTools.error("")
+               LogTools.error("")
+            }
+         }
+         else
+         {
+            project.gradle.buildFinished {
+               LogTools.warn("")
+               LogTools.warn("")
+               LogTools.warn("")
+               LogTools.warn("You are not finished publishing! Please visit https://central.sonatype.com/publishing/deployments to publish the newly created deployment.")
+               LogTools.warn("")
+               LogTools.warn("")
+               LogTools.warn("")
+            }
+         }
       }
       catch (e: Exception)
       {
@@ -727,8 +758,6 @@ open class IHMCBuildExtension(val project: Project)
       finally
       {
          connection.disconnect()
-
-         LogTools.warn("You are not finished publishing! Please visit https://central.sonatype.com/publishing/deployments to publish the newly created deployment")
       }
    }
 }


### PR DESCRIPTION
Now we check the response code from the staging portal API and print useful messages on either fail or succeed condition. I used project.gradle.buildFinished (which is deprecated but there is no replacement) to make sure the message is printed at the very end of the gradle lifecycle eg:

```
[...]
[ihmc-build] Adding dependency to POM: us.ihmc:javacpp:1.5.11-ihmc-2::compile
[ihmc-build] Adding dependency to POM: us.ihmc:ihmc-native-library-loader:2.0.4::compile
[ihmc-build] Adding dependency to POM: org.apache.commons:commons-lang3:3.12.0::compile
[ihmc-build] Adding dependency to POM: org.junit.jupiter:junit-jupiter-engine:5.9.2::runtime
[ihmc-build] 
[ihmc-build] 
[ihmc-build] 
[ihmc-build] You are not finished publishing! Please visit https://central.sonatype.com/publishing/deployments to publish the newly created deployment.
[ihmc-build] 
[ihmc-build] 
[ihmc-build] 

BUILD SUCCESSFUL in 40s
17 actionable tasks: 5 executed, 12 up-to-date
```